### PR TITLE
feat: use email as identification_id for researchers (Task #9)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,7 +16,8 @@ Reflecting active work from `SI.3 Product Backlog`.
 - **Epic 1: Extração SigPesq (Release 1)**
     - [x] US-001 [Extração Projetos SigPesq](https://github.com/ifesserra-lab/horizon_etl/issues/2) (Merged)
     - [x] US-007 [Ingestão Grupos de Pesquisa] (PR #4 - Merged)
-    - [x] T-Leaders [Implementação de Líderes] (PR #7 - In Progress)
+    - [x] T-Leaders [Implementação de Líderes] (PR #7 - Merged)
+    - [x] T-ResearcherID [E-mail como identification_id] (PR #9 - In Progress)
     - [x] US-005 Observabilidade e Idempotência (Implemented)
 
 - **Epic 3: Dados de Execução FAPES (Release 3)**

--- a/src/core/logic/research_group_loader.py
+++ b/src/core/logic/research_group_loader.py
@@ -121,9 +121,13 @@ class ResearchGroupLoader:
         # Create
         try:
             emails = [email] if email else []
-            res = self.researcher_ctrl.create_researcher(name=name, emails=emails)
+            res = self.researcher_ctrl.create_researcher(
+                name=name, 
+                emails=emails,
+                identification_id=email # Use email as ID (User requirement)
+            )
             self._researcher_cache[cache_key] = res
-            logger.info(f"Researcher created: {name} ({email})")
+            logger.info(f"Researcher created: {name} (ID: {email})")
             return res
         except Exception as e:
             logger.error(f"Error creating researcher '{name}': {e}")

--- a/tests/test_loader_mapping.py
+++ b/tests/test_loader_mapping.py
@@ -23,9 +23,10 @@ def test_research_group_loader_mapping():
     mock_research_group.name = 'Grupo Teste'
     loader.rg_ctrl.create_research_group.return_value = mock_research_group
     
+    loader.researcher_ctrl.get_all.return_value = []
     mock_researcher = MagicMock()
     mock_researcher.id = 50
-    loader.ensure_researcher = MagicMock(return_value=mock_researcher)
+    loader.researcher_ctrl.create_researcher.return_value = mock_researcher
 
     # Create invalid/dummy dataframe
     data = {
@@ -55,7 +56,11 @@ def test_research_group_loader_mapping():
         knowledge_area_ids=[1]
     )
     
-    loader.ensure_researcher.assert_called_with('Carlos Campos', 'carlos@ifes.edu.br')
+    loader.researcher_ctrl.create_researcher.assert_called_with(
+        name='Carlos Campos', 
+        emails=['carlos@ifes.edu.br'],
+        identification_id='carlos@ifes.edu.br'
+    )
     loader.rg_ctrl.add_leader.assert_called()
     
     import os


### PR DESCRIPTION
# Pull Request Template

## 🔗 Related Issues
- Fixes #9

## 📝 What was done
- Updated `ResearchGroupLoader.ensure_researcher` to pass the researcher's email as the `identification_id`.
- This ensures that researchers created from SigPesq data have a stable and unique ID derived from their contact information.
- Updated unit tests to verify this mapping.
- Verified the fix with a full application run.

## 🧪 How to test
1. Run unit tests: `PYTHONPATH=. .venv/bin/python3 tests/test_loader_mapping.py`
2. Run application: `PYTHONPATH=. .venv/bin/python3 app.py`

## 🏷️ Version
- **Target Version**: v0.1.0 (Revision)
- **Release Milestone**: R1 SigPesq
