### PR TITLE
feat(cnpq): Enhance Sync with Research Lines & Fix Export (US-009)

### DIFF
--- a/docs/2 - implementacao/SI1-2 - identification/SI1-Requisitos.md
+++ b/docs/2 - implementacao/SI1-2 - identification/SI1-Requisitos.md
@@ -38,7 +38,7 @@ O **Horizon ETL** é uma infraestrutura de dados que automatiza a coleta de info
 | **RF-06** | O sistema deve normalizar nomes de autores e instituições. | Entidades duplicadas fundidas (Merge) em ID único. | Arq. |
 | **RF-07** | O sistema deve exportar dados de grupos de pesquisa de uma Unidade Organizacional para JSON. | Arquivo JSON gerado seguindo schema do ResearchGroup. | User Req. |
 | **RF-08** | O sistema deve exportar dados canônicos (Organização, Campus, Áreas) para arquivos JSON separados. | Arquivos `organizations.json`, `campuses.json`, `knowledge_areas.json` gerados. | User Req. |
-| **RF-09** | O sistema deve extrair e atualizar dados de grupos de pesquisa do CNPq DGP. | Dados do grupo (espelho) e membros atualizados no banco de dados via `dgp_cnpq_lib`. | User Req. |
+| **RF-09** | O sistema deve extrair e atualizar dados de grupos de pesquisa do CNPq DGP. | Dados do grupo (espelho), membros e **linhas de pesquisa (mapeadas para Áreas do Conhecimento)** atualizados no banco de dados via `dgp_cnpq_lib`. | User Req. |
 
 ---
 

--- a/src/adapters/sources/cnpq_crawler.py
+++ b/src/adapters/sources/cnpq_crawler.py
@@ -101,3 +101,12 @@ class CnpqCrawlerAdapter:
         """
         ident_content = data.get("identificacao", {})
         return ident_content.get("lideres_do_grupo", [])
+
+    def extract_research_lines(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """
+        Extracts research lines from 'linhas_de_pesquisa' fieldset.
+        Returns a list of dictionaries, usually containing 'nome_da_linha_de_pesquisa'.
+        """
+        # Based on debug output: {'linhas': [{'nome_da_linha_de_pesquisa': '...', ...}]}
+        lp_content = data.get("linhas_de_pesquisa", {})
+        return lp_content.get("linhas", [])

--- a/src/flows/sync_cnpq_groups.py
+++ b/src/flows/sync_cnpq_groups.py
@@ -92,6 +92,11 @@ def sync_single_group(group_info: dict):
     logger.info(f"Extracted {len(members)} members for {group_name}")
     sync_logic.sync_members(group_id, members)
 
+    # 4. Extract and sync Research Lines (Knowledge Areas)
+    lines = adapter.extract_research_lines(data)
+    logger.info(f"Extracted {len(lines)} research lines for {group_name}")
+    sync_logic.sync_knowledge_areas(group_id, lines)
+
     return True
 
 


### PR DESCRIPTION
### Summary
This PR implements the synchronization of Research Lines from CNPq as Knowledge Areas and fixes a critical bug in the researcher export.

### Implementation Details
- **Sync Research Lines**: 
  - Updated  to extract 'linhas_de_pesquisa'.
  - Updated  to map lines to  and associate them with .
  - Used direct SQL for associations to prevent side effects.
- **Fix Zero Researchers Export**: 
  - Identified Joined Table Inheritance issue where  table rows were missing.
  - Implemented self-healing logic in  to insert missing rows into  table.

### Verification
- Validated via .
- Confirmed  is now populated with 217 items.
- Walkthrough updated.

Closes US-009