### PR TITLE
feat: implement campus filter for knowledge area mart (US-012)

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,8 +51,9 @@ def main():
 
         if flow_to_run in ["ka_mart", "all"]:
             output_path = sys.argv[2] if len(sys.argv) > 2 and flow_to_run == "ka_mart" else "data/exports/knowledge_areas_mart.json"
-            logger.info(f"Executing Flow: Export Knowledge Area Mart (Output: {output_path})")
-            export_knowledge_areas_mart_flow(output_path=output_path)
+            campus_filter = sys.argv[3] if len(sys.argv) > 3 and flow_to_run == "ka_mart" else None
+            logger.info(f"Executing Flow: Export Knowledge Area Mart (Output: {output_path}, Campus: {campus_filter})")
+            export_knowledge_areas_mart_flow(output_path=output_path, campus=campus_filter)
 
     except Exception as e:
         logger.error(f"Application failed: {e}")

--- a/docs/2 - implementacao/SI1-2 - identification/SI1-Requisitos.md
+++ b/docs/2 - implementacao/SI1-2 - identification/SI1-Requisitos.md
@@ -40,7 +40,7 @@ O **Horizon ETL** é uma infraestrutura de dados que automatiza a coleta de info
 | **RF-08** | O sistema deve exportar dados canônicos (Organização, Campus, Áreas) para arquivos JSON separados, permitindo filtragem por Campus. | Arquivos `organizations.json`, `campuses.json`, `knowledge_areas.json` gerados. Filtro de Campus suportado. | User Req. |
 | **RF-09** | O sistema deve extrair e atualizar dados de grupos de pesquisa do CNPq DGP (identificação, linhas de pesquisa, membros). | Dados do grupo (espelho), membros e **linhas de pesquisa (mapeadas para Áreas do Conhecimento)** atualizados no banco de dados via `dgp_cnpq_lib`. | User Req. |
 | **RF-10** | O sistema deve identificar e sincronizar membros egressos do CNPq, registrando corretamente as datas de início e fim de participação. | Membros egressos identificados e datas de participação (início/fim) persistidas no Supabase. | User Req. |
-| **RF-11** | O sistema deve gerar um "Mart JSON" que consolida as Áreas de Pesquisa com seus Grupos e Campi vinculados. | Arquivo `knowledge_areas_mart.json` gerado com estatísticas por área. | User Req. |
+| **RF-11** | O sistema deve gerar um "Mart JSON" que consolida as Áreas de Pesquisa com seus Grupos e Campi vinculados, permitindo filtragem por campus. | Arquivo `knowledge_areas_mart.json` gerado com estatísticas por área. Filtro de campus suportado. | User Req. |
 
 ---
 

--- a/docs/2 - implementacao/SI3 - initiation/SI.3-product_backlog_initiation.md
+++ b/docs/2 - implementacao/SI3 - initiation/SI.3-product_backlog_initiation.md
@@ -213,6 +213,7 @@ Gerar um arquivo JSON consolidado que vincula Áreas de Conhecimento aos Grupos 
     - [x] Leitura direta do Banco de Dados via Controllers.
     - [x] Agregação de contagem de grupos por área.
     - [x] Listagem de nomes de campi únicos por área.
+    - [ ] Parametrização de filtro de campus.
 - **Deploy**:
     - [x] Comando `ka_mart` integrado ao `app.py`.
     - [x] Passo final do `full_pipeline`.

--- a/src/core/logic/mart_generator.py
+++ b/src/core/logic/mart_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from loguru import logger
 import json
 import os
@@ -10,12 +10,16 @@ class KnowledgeAreaMartGenerator:
         self.rg_ctrl = ResearchGroupController()
         self.campus_ctrl = CampusController()
 
-    def generate(self, output_path: str):
+    def generate(self, output_path: str, campus_filter: Optional[str] = None):
         """
         Generates a Research Area Mart JSON file.
         Associates knowledge areas with research groups and campuses.
+        
+        Args:
+            output_path: Destination JSON file path.
+            campus_filter: Optional campus name to filter groups.
         """
-        logger.info(f"Generating Knowledge Area Mart to {output_path}")
+        logger.info(f"Generating Knowledge Area Mart to {output_path} (Filter: {campus_filter})")
         
         try:
             # 1. Fetch data from DB
@@ -24,6 +28,17 @@ class KnowledgeAreaMartGenerator:
             all_campuses = self.campus_ctrl.get_all()
 
             logger.info(f"Loaded {len(all_areas)} areas, {len(all_groups)} groups, and {len(all_campuses)} campuses.")
+
+            # Filter groups by campus if requested
+            groups_to_process = all_groups
+            if campus_filter:
+                target_campus = next((c for c in all_campuses if c.name.lower() == campus_filter.lower()), None)
+                if not target_campus:
+                    logger.warning(f"Campus '{campus_filter}' not found. Mart will have 0 groups.")
+                    groups_to_process = []
+                else:
+                    groups_to_process = [g for g in all_groups if g.campus_id == target_campus.id]
+                    logger.info(f"Filtered {len(groups_to_process)} groups for campus {target_campus.name}")
 
             # Create campus map for optimization
             campus_map = {c.id: c.name for c in all_campuses}
@@ -40,7 +55,7 @@ class KnowledgeAreaMartGenerator:
                     "campuses": set()
                 }
 
-            for group in all_groups:
+            for group in groups_to_process:
                 campus_name = campus_map.get(group.campus_id, "Unknown")
                 
                 # Check groups knowledge areas

--- a/src/flows/export_knowledge_areas_mart.py
+++ b/src/flows/export_knowledge_areas_mart.py
@@ -1,30 +1,32 @@
 from prefect import flow, task, get_run_logger
+from typing import Optional
 import os
 from src.core.logic.mart_generator import KnowledgeAreaMartGenerator
 
 @task(name="generate_ka_mart_task")
-def generate_ka_mart_task(output_path: str):
+def generate_ka_mart_task(output_path: str, campus: Optional[str] = None):
     logger = get_run_logger()
     logger.info(f"Starting Knowledge Area Mart generation task to {output_path}...")
     
     generator = KnowledgeAreaMartGenerator()
-    generator.generate(output_path)
+    generator.generate(output_path, campus_filter=campus)
     
     logger.info("Knowledge Area Mart generation task completed.")
 
 @flow(name="Export Knowledge Area Mart Flow")
-def export_knowledge_areas_mart_flow(output_path: str = "data/exports/knowledge_areas_mart.json"):
+def export_knowledge_areas_mart_flow(output_path: str = "data/exports/knowledge_areas_mart.json", campus: Optional[str] = None):
     """
     Flow to generate the Knowledge Area Mart JSON from database.
     
     Args:
         output_path: Path where the mart JSON will be saved.
+        campus: Optional campus name filter.
     """
     # Ensure absolute path or relative to CWD
     if not os.path.isabs(output_path):
         output_path = os.path.join(os.getcwd(), output_path)
         
-    generate_ka_mart_task(output_path)
+    generate_ka_mart_task(output_path, campus)
 
 if __name__ == "__main__":
     export_knowledge_areas_mart_flow()

--- a/src/flows/unified_pipeline.py
+++ b/src/flows/unified_pipeline.py
@@ -36,7 +36,7 @@ def full_ingestion_pipeline(
     # 4. Generate Knowledge Area Mart
     mart_path = os.path.join(output_dir, "knowledge_areas_mart.json")
     logger.info(f"Step 4/4: Generating Knowledge Area Mart at {mart_path}...")
-    export_knowledge_areas_mart_flow(output_path=mart_path)
+    export_knowledge_areas_mart_flow(output_path=mart_path, campus=campus_name)
 
     logger.info("Unified Ingestion Pipeline completed successfully.")
 


### PR DESCRIPTION
## Description
Implements filtering by Campus for the Knowledge Area Mart generation (US-012).

### Changes
- Modified `KnowledgeAreaMartGenerator`: Added logic to filter research groups by campus before aggregation.
- Modified `export_knowledge_areas_mart.py`: Updated flow to accept `campus` parameter.
- Updated `app.py`: CLI accepts 3rd argument as campus filter for `ka_mart` command.
- Updated `unified_pipeline.py`: Passes `campus` filter to mart generation step.

## Related Issues
Closes US-012 (Filtering Requirement)

## How to Test
Run the mart generation with a campus argument:
```bash
python app.py ka_mart data/exports/mart_serra.json "Serra"
```
Verify that the output JSON only contains groups from the specified campus.
