### PR TITLE
fix: exclude empty knowledge areas from mart export

### DIFF
--- a/src/core/logic/mart_generator.py
+++ b/src/core/logic/mart_generator.py
@@ -74,8 +74,9 @@ class KnowledgeAreaMartGenerator:
             mart_list = []
             for area_id in sorted(area_mart.keys()):
                 item = area_mart[area_id]
-                item["campuses"] = sorted(list(item["campuses"]))
-                mart_list.append(item)
+                if item["groups_count"] > 0:
+                    item["campuses"] = sorted(list(item["campuses"]))
+                    mart_list.append(item)
 
             # 4. Save to JSON
             os.makedirs(os.path.dirname(output_path), exist_ok=True)


### PR DESCRIPTION
## Description
Exclude Knowledge Areas with 0 associated groups from the Mart JSON export.

### Changes
- Modified `KnowledgeAreaMartGenerator` to skip areas where `groups_count == 0`.

## Related Issues
Enhancement for US-012.

## How to Test
Run `python app.py ka_mart out.json`.
Verify no area in output has `"groups": []`.
