### PR TITLE
feat: include member start/end dates in research group export

### DIFF
--- a/src/core/logic/research_group_exporter.py
+++ b/src/core/logic/research_group_exporter.py
@@ -109,7 +109,9 @@ class ResearchGroupExporter:
                             "name": person_name,
                             "role": role_name,
                             "lattes_url": lattes,
-                            "emails": email_list  # Export all emails
+                            "emails": email_list,
+                            "start_date": tm.start_date.strftime('%Y-%m-%d') if tm.start_date else None,
+                            "end_date": tm.end_date.strftime('%Y-%m-%d') if tm.end_date else None
                         }
                         
                         # Deduplicate members list based on person_id


### PR DESCRIPTION
## Description
Include `start_date` and `end_date` in the members list of the Research Group export.

### Changes
- Modified `ResearchGroupExporter.to_dict` logic to include date fields.
- Dates are formatted as `YYYY-MM-DD` or `null`.

## Related Issues
Requested by user.

## How to Test
Run `python app.py export_canonical data/exports`.
Check `research_groups_canonical.json` for `start_date` and `end_date` keys in member objects.
