### PR TITLE
refactor: enrichment de projetos (match único + rapidfuzz + transação + testes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "openpyxl>=3.1.0",
     "thefuzz>=0.22.0",
+    "rapidfuzz>=3.0.0",
     "python-Levenshtein>=0.25.0",
     "python-dotenv>=1.0.0",
     "sigpesq-agent @ git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ requests>=2.30.0
 beautifulsoup4>=4.12.0
 openpyxl>=3.1.0
 thefuzz>=0.22.0
+rapidfuzz>=3.0.0
 python-Levenshtein>=0.25.0
 python-dotenv>=1.0.0
 git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.0

--- a/src/core/logic/project_enrichment.py
+++ b/src/core/logic/project_enrichment.py
@@ -2,20 +2,27 @@ import glob
 import json
 import os
 import re
-from difflib import SequenceMatcher
-from typing import Any, Dict, List, Optional, Tuple
+from datetime import datetime
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from eo_lib import InitiativeController
 from loguru import logger
+from rapidfuzz import fuzz, process
 from sqlalchemy import text
 
 from src.core.logic.initiative_identity import normalize_text
 from src.tracking.recorder import tracking_recorder
 
 RESEARCH_PROJECT_TYPE = "Research Project"
-FUZZY_THRESHOLD = 0.90
+# rapidfuzz ratio is on a 0-100 scale.
+FUZZY_THRESHOLD = 90.0
+NEW_FROM_DOCUMENT = "new_from_document"
+STRATEGY_PRIORITY = {"sigpesq_project_code": 0, "title_exact": 1, "title_fuzzy": 2}
 
 
+# --------------------------------------------------------------------------- #
+# Pure helpers (no DB / no I/O) — unit-tested in tests/test_project_enrichment.py
+# --------------------------------------------------------------------------- #
 def normalize_project_code(value: Any) -> str:
     """Extracts the numeric SigPesq project code from a value like 'PJ 6020'."""
     if value is None:
@@ -24,34 +31,163 @@ def normalize_project_code(value: Any) -> str:
     return match.group(0) if match else ""
 
 
+def compose_description(pj: Dict[str, Any]) -> Optional[str]:
+    """Prefers the free-text ``descricao``; falls back to the general objective."""
+    desc = (pj.get("descricao") or "").strip()
+    if desc:
+        return desc
+    geral = ((pj.get("objetivos") or {}).get("geral") or "").strip()
+    return geral or None
+
+
+def build_enrichment(
+    pj: Dict[str, Any], *, code: str, strategy: str, needs_review: bool
+) -> Dict[str, Any]:
+    """Assembles the ``enrichment_json`` payload from a PJ document."""
+    meta = pj.get("_meta") or {}
+    return {
+        "source": ProjectEnrichmentLoader.SOURCE_SYSTEM,
+        "project_code": code or None,
+        "match_strategy": strategy,
+        "needs_review": needs_review,
+        "objetivos": pj.get("objetivos") or {},
+        "cronograma": pj.get("cronograma") or [],
+        "linha_pesquisa": pj.get("linha_pesquisa"),
+        "palavras_chave": pj.get("palavras_chave") or [],
+        "area_conhecimento": pj.get("area_conhecimento"),
+        "extracted_at": meta.get("extraido_em"),
+        "extraction_model": meta.get("modelo"),
+        "source_file": meta.get("arquivo"),
+    }
+
+
+def parse_sql_datetime(value: Any) -> Optional[str]:
+    """Turns a 'YYYY-MM-DD' string into the datetime format the ORM stores."""
+    if not value:
+        return None
+    match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", str(value))
+    if not match:
+        return None
+    return f"{match.group(1)}-{match.group(2)}-{match.group(3)} 00:00:00.000000"
+
+
+def derive_status(start: Optional[str], end: Optional[str], *, now: datetime) -> str:
+    """Best-effort status for a documented project without a diretoria parecer.
+
+    ``now`` is injected so the result is deterministic and testable.
+    """
+    if end:
+        match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", str(end))
+        if match:
+            end_dt = datetime(
+                int(match.group(1)), int(match.group(2)), int(match.group(3))
+            )
+            return "Concluded" if end_dt < now else "Active"
+    return "Active" if start else "Unknown"
+
+
+class Match(NamedTuple):
+    initiative_id: int
+    strategy: str
+    needs_review: bool
+
+
+def match_pj(
+    pj: Dict[str, Any],
+    code_index: Dict[str, int],
+    name_index: Dict[str, List[int]],
+    fuzzy_choices: Dict[int, str],
+) -> Optional[Match]:
+    """Resolves a PJ document to an existing initiative, most-confident first.
+
+    code (approved SigPesq) > exact normalized title > fuzzy title >= threshold.
+    Returns ``None`` when nothing matches.
+    """
+    code = normalize_project_code(pj.get("codigo"))
+    if code and code in code_index:
+        return Match(code_index[code], "sigpesq_project_code", False)
+
+    norm_title = normalize_text(pj.get("titulo")) if pj.get("titulo") else ""
+    if not norm_title:
+        return None
+
+    exact = name_index.get(norm_title)
+    if exact:
+        # Unique exact match is trusted; an ambiguous one is flagged for review.
+        return Match(exact[0], "title_exact", len(exact) > 1)
+
+    if fuzzy_choices:
+        best = process.extractOne(
+            norm_title,
+            fuzzy_choices,
+            scorer=fuzz.ratio,
+            score_cutoff=FUZZY_THRESHOLD,
+        )
+        if best is not None:
+            return Match(best[2], "title_fuzzy", True)
+    return None
+
+
+class Candidate(NamedTuple):
+    path: str
+    pj: Dict[str, Any]
+    match: Optional[Match]
+
+
+def resolve_claims(candidates: List[Candidate]) -> Tuple[List[Candidate], int]:
+    """De-duplicates matched candidates so each initiative is claimed once by the
+    highest-confidence match (code > title_exact > title_fuzzy; ties by filename).
+
+    Returns (winners, collision_count). Unmatched candidates are ignored here.
+    """
+    matched = [c for c in candidates if c.match is not None]
+    ordered = sorted(
+        matched,
+        key=lambda c: (STRATEGY_PRIORITY[c.match.strategy], c.path),
+    )
+    claimed: set[int] = set()
+    winners: List[Candidate] = []
+    collisions = 0
+    for c in ordered:
+        if c.match.initiative_id in claimed:
+            collisions += 1
+            continue
+        claimed.add(c.match.initiative_id)
+        winners.append(c)
+    return winners, collisions
+
+
+def is_ingestable(pj: Dict[str, Any]) -> bool:
+    """A PJ document is rich enough to become a new initiative when it has a
+    title, a description and either objectives or a schedule."""
+    title = (pj.get("titulo") or "").strip()
+    descricao = (pj.get("descricao") or "").strip()
+    geral = ((pj.get("objetivos") or {}).get("geral") or "").strip()
+    cronograma = pj.get("cronograma") or []
+    return bool(title and descricao and (geral or cronograma))
+
+
+# --------------------------------------------------------------------------- #
+# Loader
+# --------------------------------------------------------------------------- #
 class ProjectEnrichmentLoader:
     """
-    Enriches Research Project initiatives ALREADY in the database with content
-    extracted from SigPesq project document files (``PJ_*.json``).
+    Enriches Research Project initiatives with content extracted from SigPesq
+    project document files (``PJ_*.json``), and optionally ingests rich documents
+    that match no existing initiative as new initiatives.
 
-    Scope
-    -----
-    * Only initiatives that already exist as Research Projects in the DB.
-      A PJ file is matched to an initiative by, in order of confidence:
-        1. ``sigpesq_project_code``  — the code recorded in the tracking tables
-           when the SigPesq Excel report was ingested. These initiatives are all
-           APPROVED (``ParecerDiretoria == "Aprovado"``); the Excel loader only
-           persists approved projects.
-        2. ``title_exact``           — normalized title equals a Research Project
-           initiative name (unique match).
-        3. ``title_fuzzy``           — best normalized-title similarity ≥ 0.90.
-           Flagged ``needs_review`` because a fuzzy match can be a false positive.
-      PJ files matching nothing (truly new projects) are skipped.
+    Matching (per document, most confident first):
+      1. ``sigpesq_project_code`` — tracking-table link; these are APPROVED.
+      2. ``title_exact``          — normalized title equals a Research Project name.
+      3. ``title_fuzzy``          — best title similarity >= 90 (``needs_review``).
 
-    What is written
-    ---------------
-    * ``description`` (initiatives column): filled only when currently empty,
-      unless ``overwrite=True``. Excel ``Resumo`` stays authoritative otherwise.
-    * ``enrichment_json`` (new initiatives column): the richer document fields
-      that have no dedicated column — objectives, dated schedule, research line,
-      structured keywords, knowledge area — plus provenance and the match
-      strategy / ``needs_review`` flag. Always (re)written for a matched project,
-      since this loader fully owns that column.
+    Writes:
+      * ``description`` — filled only when empty (unless ``overwrite``).
+      * ``enrichment_json`` — objectives / schedule / research line / keywords /
+        area + provenance + match strategy / ``needs_review``. Always (re)written.
+
+    All writes for one run happen in a single transaction; a row that fails is
+    rolled back to a savepoint and skipped without aborting the others.
     """
 
     SOURCE_SYSTEM = "sigpesq_project_files"
@@ -65,9 +201,13 @@ class ProjectEnrichmentLoader:
     def _session(self):
         return self.controller._service._repository._session
 
-    # ------------------------------------------------------------------ schema
+    # -------------------------------------------------------------- schema
     def ensure_schema(self) -> None:
-        """Adds the ``enrichment_json`` column to ``initiatives`` if missing."""
+        """Adds the ``enrichment_json`` column to ``initiatives`` if missing.
+
+        NOTE: runtime DDL is a pragmatic stopgap — this belongs in a real
+        migration once the project adopts a migration tool.
+        """
         cols = {
             row[1]
             for row in self._session.execute(
@@ -81,7 +221,7 @@ class ProjectEnrichmentLoader:
             )
             self._session.commit()
 
-    # ------------------------------------------------------------------ indexes
+    # -------------------------------------------------------------- indexes
     def _load_code_index(self) -> Dict[str, int]:
         """``project_code -> initiative_id`` for APPROVED SigPesq projects, using
         the tracking tables as the authoritative code<->initiative link."""
@@ -117,9 +257,9 @@ class ProjectEnrichmentLoader:
 
     def _load_research_project_names(
         self,
-    ) -> Tuple[Dict[str, List[int]], List[Tuple[int, str]]]:
-        """Returns (normalized_name -> [initiative_id], [(id, normalized_name)]) for
-        Research Project initiatives only (advisorships excluded)."""
+    ) -> Tuple[Dict[str, List[int]], Dict[int, str]]:
+        """Returns (normalized_name -> [initiative_id], {initiative_id -> normalized_name})
+        for Research Project initiatives only (advisorships excluded)."""
         rows = self._session.execute(
             text(
                 """
@@ -133,14 +273,14 @@ class ProjectEnrichmentLoader:
         ).fetchall()
 
         by_name: Dict[str, List[int]] = {}
-        norm_list: List[Tuple[int, str]] = []
+        fuzzy_choices: Dict[int, str] = {}
         for init_id, name in rows:
             norm = normalize_text(name)
             if not norm:
                 continue
             by_name.setdefault(norm, []).append(init_id)
-            norm_list.append((init_id, norm))
-        return by_name, norm_list
+            fuzzy_choices[init_id] = norm
+        return by_name, fuzzy_choices
 
     def _load_current_descriptions(self) -> Dict[int, str]:
         rows = self._session.execute(
@@ -148,82 +288,64 @@ class ProjectEnrichmentLoader:
         ).fetchall()
         return {row[0]: (row[1] or "") for row in rows}
 
-    # ------------------------------------------------------------------ matching
-    def _match(
-        self,
-        pj: Dict[str, Any],
-        code_index: Dict[str, int],
-        name_index: Dict[str, List[int]],
-        norm_names: List[Tuple[int, str]],
-    ) -> Optional[Tuple[int, str, bool]]:
-        """Returns (initiative_id, match_strategy, needs_review) or None."""
-        code = normalize_project_code(pj.get("codigo"))
-        if code and code in code_index:
-            return code_index[code], "sigpesq_project_code", False
+    def _lookup_org_and_type(self) -> Tuple[Optional[int], int]:
+        type_row = self._session.execute(
+            text("SELECT id FROM initiative_types WHERE name = :n LIMIT 1"),
+            {"n": RESEARCH_PROJECT_TYPE},
+        ).fetchone()
+        type_id = type_row[0] if type_row else 1
+        org_row = self._session.execute(
+            text(
+                """
+                SELECT organization_id FROM initiatives
+                WHERE organization_id IS NOT NULL
+                GROUP BY organization_id ORDER BY COUNT(*) DESC LIMIT 1
+                """
+            )
+        ).fetchone()
+        return (org_row[0] if org_row else None), type_id
 
-        title = pj.get("titulo")
-        norm_title = normalize_text(title) if title else ""
-        if not norm_title:
-            return None
+    # -------------------------------------------------------------- read
+    def _read_documents(self, pj_dir: str) -> List[Tuple[str, Dict[str, Any]]]:
+        docs: List[Tuple[str, Dict[str, Any]]] = []
+        for path in sorted(glob.glob(os.path.join(pj_dir, "PJ_*.json"))):
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    docs.append((path, json.load(fh)))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(f"Could not read {path}: {exc}")
+        return docs
 
-        exact = name_index.get(norm_title)
-        if exact:
-            # Unique exact match is trusted; ambiguous one is flagged for review.
-            return exact[0], "title_exact", len(exact) > 1
-
-        best_id, best_ratio = None, 0.0
-        for init_id, cand in norm_names:
-            ratio = SequenceMatcher(None, norm_title, cand).ratio()
-            if ratio > best_ratio:
-                best_id, best_ratio = init_id, ratio
-        if best_id is not None and best_ratio >= FUZZY_THRESHOLD:
-            return best_id, "title_fuzzy", True
-        return None
-
-    # ------------------------------------------------------------------ payload
-    @staticmethod
-    def _compose_description(pj: Dict[str, Any]) -> Optional[str]:
-        """Prefers the free-text ``descricao``; falls back to the general objective."""
-        desc = (pj.get("descricao") or "").strip()
-        if desc:
-            return desc
-        geral = ((pj.get("objetivos") or {}).get("geral") or "").strip()
-        return geral or None
-
-    @staticmethod
-    def _build_enrichment(
-        pj: Dict[str, Any], *, code: str, strategy: str, needs_review: bool
-    ) -> Dict[str, Any]:
-        meta = pj.get("_meta") or {}
-        return {
-            "source": ProjectEnrichmentLoader.SOURCE_SYSTEM,
-            "project_code": code or None,
-            "match_strategy": strategy,
-            "needs_review": needs_review,
-            "objetivos": pj.get("objetivos") or {},
-            "cronograma": pj.get("cronograma") or [],
-            "linha_pesquisa": pj.get("linha_pesquisa"),
-            "palavras_chave": pj.get("palavras_chave") or [],
-            "area_conhecimento": pj.get("area_conhecimento"),
-            "extracted_at": meta.get("extraido_em"),
-            "extraction_model": meta.get("modelo"),
-            "source_file": meta.get("arquivo"),
-        }
-
-    # ------------------------------------------------------------------ main
+    # -------------------------------------------------------------- public API
     def load(self, pj_dir: str) -> Dict[str, int]:
+        """Enrich existing initiatives only."""
+        return self.run(pj_dir, ingest_new=False)
+
+    def ingest_unmatched(self, pj_dir: str) -> Dict[str, int]:
+        """Enrich existing AND create new initiatives from unmatched rich docs."""
+        return self.run(pj_dir, ingest_new=True)
+
+    def run(self, pj_dir: str, *, ingest_new: bool = False) -> Dict[str, int]:
+        """Reads the documents once, classifies them once, then enriches matched
+        initiatives (deduplicated) and, if requested, ingests unmatched rich ones.
+        All writes share one transaction; a failing row is skipped via savepoint.
+        """
         self.ensure_schema()
 
         code_index = self._load_code_index()
-        name_index, norm_names = self._load_research_project_names()
+        name_index, fuzzy_choices = self._load_research_project_names()
         descriptions = self._load_current_descriptions()
+        docs = self._read_documents(pj_dir)
         logger.info(
-            f"Indexes ready: {len(code_index)} approved-by-code, "
-            f"{len(norm_names)} research-project names"
+            f"{len(docs)} documents | {len(code_index)} approved-by-code | "
+            f"{len(fuzzy_choices)} research-project names"
         )
 
-        files = sorted(glob.glob(os.path.join(pj_dir, "PJ_*.json")))
-        logger.info(f"Found {len(files)} PJ document files in {pj_dir}")
+        candidates = [
+            Candidate(path, pj, match_pj(pj, code_index, name_index, fuzzy_choices))
+            for path, pj in docs
+        ]
+        winners, collisions = resolve_claims(candidates)
 
         stats = {
             "enriched": 0,
@@ -233,96 +355,187 @@ class ProjectEnrichmentLoader:
             "by_code": 0,
             "by_title_exact": 0,
             "by_title_fuzzy": 0,
-            "skipped_no_match": 0,
-            "skipped_collision": 0,
+            "skipped_no_match": sum(1 for c in candidates if c.match is None),
+            "skipped_collision": collisions,
+            "errors": 0,
         }
 
-        # First pass: match every file. Then resolve so each initiative is
-        # enriched at most once, highest-confidence match winning
-        # (code > title_exact > title_fuzzy). This prevents a low-confidence
-        # title match from overwriting a code match on the same initiative.
-        priority = {"sigpesq_project_code": 0, "title_exact": 1, "title_fuzzy": 2}
-        candidates = []
-        for path in files:
-            try:
-                with open(path, encoding="utf-8") as fh:
-                    pj = json.load(fh)
-            except (OSError, json.JSONDecodeError) as exc:
-                logger.warning(f"Could not read {path}: {exc}")
-                continue
-            match = self._match(pj, code_index, name_index, norm_names)
-            if not match:
-                stats["skipped_no_match"] += 1
-                continue
-            init_id, strategy, needs_review = match
-            candidates.append(
-                (priority[strategy], path, pj, init_id, strategy, needs_review)
+        transaction = None if self.dry_run else self._session.begin()
+        try:
+            self._enrich_winners(winners, descriptions, stats)
+            if ingest_new:
+                unmatched = [c for c in candidates if c.match is None]
+                stats.update(self._ingest_new(unmatched, name_index))
+            if transaction is not None:
+                transaction.commit()
+        except Exception:
+            if transaction is not None:
+                transaction.rollback()
+            raise
+
+        logger.info(
+            f"Enrichment complete ({'dry-run' if self.dry_run else 'applied'}, "
+            f"ingest_new={ingest_new}): {stats}"
+        )
+        return stats
+
+    # -------------------------------------------------------------- enrich
+    def _enrich_winners(
+        self,
+        winners: List[Candidate],
+        descriptions: Dict[int, str],
+        stats: Dict[str, int],
+    ) -> None:
+        for cand in winners:
+            init_id = cand.match.initiative_id
+            strategy = cand.match.strategy
+            code = normalize_project_code(cand.pj.get("codigo"))
+            enrichment = build_enrichment(
+                cand.pj,
+                code=code,
+                strategy=strategy,
+                needs_review=cand.match.needs_review,
             )
-
-        candidates.sort(key=lambda c: (c[0], c[1]))
-        claimed: set[int] = set()
-
-        for _prio, path, pj, init_id, strategy, needs_review in candidates:
-            if init_id in claimed:
-                stats["skipped_collision"] += 1
-                logger.debug(
-                    f"init {init_id} already claimed; skipping {os.path.basename(path)}"
-                )
-                continue
-            claimed.add(init_id)
-
-            code = normalize_project_code(pj.get("codigo"))
-            enrichment = self._build_enrichment(
-                pj, code=code, strategy=strategy, needs_review=needs_review
-            )
-
-            # description policy: fill only when empty (unless overwrite)
-            new_desc = self._compose_description(pj)
+            new_desc = compose_description(cand.pj)
             current = descriptions.get(init_id, "").strip()
             write_desc = bool(new_desc) and (self.overwrite or not current)
 
             if self.dry_run:
-                action = (
-                    "fill"
-                    if (write_desc and not current)
-                    else ("overwrite" if write_desc else "keep")
-                )
                 logger.info(
-                    f"[dry-run][{strategy}] init {init_id} desc={action} "
-                    f"review={needs_review} (code={code or '-'})"
+                    f"[dry-run][{strategy}] init {init_id} "
+                    f"desc={'write' if write_desc else 'keep'} "
+                    f"review={cand.match.needs_review} (code={code or '-'})"
                 )
             else:
-                self._apply(init_id, enrichment, new_desc if write_desc else None)
+                written = self._write_row(
+                    lambda: self._apply(
+                        init_id, enrichment, new_desc if write_desc else None
+                    )
+                )
+                if not written:
+                    stats["errors"] += 1
+                    continue
                 self._record_tracking(
                     init_id=init_id,
                     code=code,
                     strategy=strategy,
                     enrichment=enrichment,
                     desc_written=new_desc if write_desc else None,
-                    path=path,
-                    pj=pj,
+                    path=cand.path,
+                    pj=cand.pj,
                 )
 
             stats["enriched"] += 1
             stats[
-                "by_"
-                + {
-                    "sigpesq_project_code": "code",
-                    "title_exact": "title_exact",
-                    "title_fuzzy": "title_fuzzy",
-                }[strategy]
+                f"by_{'code' if strategy == 'sigpesq_project_code' else strategy}"
             ] += 1
-            if needs_review:
+            if cand.match.needs_review:
                 stats["needs_review"] += 1
             if write_desc and not current:
                 stats["desc_filled"] += 1
             elif current and not self.overwrite:
                 stats["desc_kept_existing"] += 1
 
-        logger.info(
-            f"Enrichment complete ({'dry-run' if self.dry_run else 'applied'}): {stats}"
-        )
+    # -------------------------------------------------------------- ingest
+    def _ingest_new(
+        self, unmatched: List[Candidate], name_index: Dict[str, List[int]]
+    ) -> Dict[str, int]:
+        org_id, type_id = self._lookup_org_and_type()
+        existing_names = set(name_index.keys())
+        seen_titles: set[str] = set()
+        stats = {"created": 0, "skipped_poor": 0, "skipped_duplicate": 0}
+
+        for cand in unmatched:
+            pj = cand.pj
+            if not is_ingestable(pj):
+                stats["skipped_poor"] += 1
+                continue
+            norm = normalize_text(pj.get("titulo"))
+            if norm in existing_names or norm in seen_titles:
+                stats["skipped_duplicate"] += 1
+                continue
+            seen_titles.add(norm)
+
+            if self.dry_run:
+                stats["created"] += 1
+                logger.info(
+                    f"[dry-run][new] would create '{(pj.get('titulo') or '')[:60]}'"
+                )
+                continue
+
+            if self._create_initiative(cand, org_id, type_id):
+                existing_names.add(norm)
+                stats["created"] += 1
+
         return stats
+
+    def _create_initiative(
+        self, cand: Candidate, org_id: Optional[int], type_id: int
+    ) -> bool:
+        pj = cand.pj
+        code = normalize_project_code(pj.get("codigo"))
+        enrichment = build_enrichment(
+            pj, code=code, strategy=NEW_FROM_DOCUMENT, needs_review=True
+        )
+        datas = pj.get("datas") or {}
+        description = compose_description(pj)
+        params = {
+            "name": (pj.get("titulo") or "").strip(),
+            "status": derive_status(
+                datas.get("inicio"), datas.get("fim"), now=datetime.now()
+            ),
+            "desc": description,
+            "start": parse_sql_datetime(datas.get("inicio")),
+            "end": parse_sql_datetime(datas.get("fim")),
+            "type_id": type_id,
+            "org_id": org_id,
+            "j": json.dumps(enrichment, ensure_ascii=False),
+        }
+        new_id_box: Dict[str, Optional[int]] = {"id": None}
+
+        def _do():
+            result = self._session.execute(
+                text(
+                    """
+                    INSERT INTO initiatives
+                        (name, status, description, start_date, end_date,
+                         initiative_type_id, organization_id, parent_id, enrichment_json)
+                    VALUES (:name, :status, :desc, :start, :end,
+                            :type_id, :org_id, NULL, :j)
+                    """
+                ),
+                params,
+            )
+            new_id_box["id"] = result.lastrowid
+
+        if not self._write_row(_do):
+            return False
+
+        self._record_tracking(
+            init_id=new_id_box["id"],
+            code=code,
+            strategy=NEW_FROM_DOCUMENT,
+            enrichment=enrichment,
+            desc_written=description,
+            path=cand.path,
+            pj=pj,
+        )
+        logger.info(
+            f"[new] initiative {new_id_box['id']} created: {params['name'][:60]}"
+        )
+        return True
+
+    # -------------------------------------------------------------- write helpers
+    def _write_row(self, fn) -> bool:
+        """Runs a single write inside a SAVEPOINT so one failing row is skipped
+        without aborting the surrounding transaction."""
+        try:
+            with self._session.begin_nested():
+                fn()
+            return True
+        except Exception as exc:
+            logger.warning(f"Row write failed, skipping: {exc}")
+            return False
 
     def _apply(
         self, init_id: int, enrichment: Dict[str, Any], description: Optional[str]
@@ -331,7 +544,8 @@ class ProjectEnrichmentLoader:
         if description:
             self._session.execute(
                 text(
-                    "UPDATE initiatives SET description = :d, enrichment_json = :j WHERE id = :id"
+                    "UPDATE initiatives SET description = :d, enrichment_json = :j "
+                    "WHERE id = :id"
                 ),
                 {"d": description, "j": payload, "id": init_id},
             )
@@ -340,7 +554,6 @@ class ProjectEnrichmentLoader:
                 text("UPDATE initiatives SET enrichment_json = :j WHERE id = :id"),
                 {"j": payload, "id": init_id},
             )
-        self._session.commit()
 
     def _record_tracking(
         self,
@@ -389,152 +602,3 @@ class ProjectEnrichmentLoader:
             after={"initiative_id": init_id, **selected},
             reason="ProjectEnrichmentLoader applied",
         )
-
-    # ------------------------------------------------------- ingest new
-    @staticmethod
-    def _parse_sql_datetime(value: Any) -> Optional[str]:
-        """Turns a 'YYYY-MM-DD' string into the datetime format the ORM stores."""
-        if not value:
-            return None
-        match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", str(value))
-        if not match:
-            return None
-        return f"{match.group(1)}-{match.group(2)}-{match.group(3)} 00:00:00.000000"
-
-    @staticmethod
-    def _derive_status(start: Optional[str], end: Optional[str]) -> str:
-        """Best-effort status for a documented project without a diretoria parecer."""
-        from datetime import datetime
-
-        if end:
-            match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", str(end))
-            if match:
-                end_dt = datetime(
-                    int(match.group(1)), int(match.group(2)), int(match.group(3))
-                )
-                return "Concluded" if end_dt < datetime.now() else "Active"
-        return "Active" if start else "Unknown"
-
-    def _lookup_org_and_type(self) -> Tuple[Optional[int], int]:
-        type_row = self._session.execute(
-            text("SELECT id FROM initiative_types WHERE name = :n LIMIT 1"),
-            {"n": RESEARCH_PROJECT_TYPE},
-        ).fetchone()
-        type_id = type_row[0] if type_row else 1
-        org_row = self._session.execute(
-            text(
-                """
-                SELECT organization_id FROM initiatives
-                WHERE organization_id IS NOT NULL
-                GROUP BY organization_id ORDER BY COUNT(*) DESC LIMIT 1
-                """
-            )
-        ).fetchone()
-        return (org_row[0] if org_row else None), type_id
-
-    def ingest_unmatched(self, pj_dir: str) -> Dict[str, int]:
-        """
-        Creates NEW Research Project initiatives from PJ document files that match
-        no existing initiative. Only content-rich files are ingested (title +
-        description + general objective or schedule); titles are deduplicated and
-        anything whose name already exists is skipped. Every created initiative is
-        flagged ``needs_review`` inside its enrichment payload.
-        """
-        self.ensure_schema()
-        code_index = self._load_code_index()
-        name_index, norm_names = self._load_research_project_names()
-        existing_names = set(name_index.keys())
-        org_id, type_id = self._lookup_org_and_type()
-
-        files = sorted(glob.glob(os.path.join(pj_dir, "PJ_*.json")))
-        stats = {
-            "created": 0,
-            "skipped_matched": 0,
-            "skipped_poor": 0,
-            "skipped_duplicate": 0,
-        }
-        seen_titles: set[str] = set()
-
-        for path in files:
-            try:
-                with open(path, encoding="utf-8") as fh:
-                    pj = json.load(fh)
-            except (OSError, json.JSONDecodeError) as exc:
-                logger.warning(f"Could not read {path}: {exc}")
-                continue
-
-            if self._match(pj, code_index, name_index, norm_names) is not None:
-                stats["skipped_matched"] += 1
-                continue
-
-            title = (pj.get("titulo") or "").strip()
-            descricao = (pj.get("descricao") or "").strip()
-            geral = ((pj.get("objetivos") or {}).get("geral") or "").strip()
-            cronograma = pj.get("cronograma") or []
-            # Content bar: needs a title, a description, and either objectives or a schedule.
-            if not title or not descricao or not (geral or cronograma):
-                stats["skipped_poor"] += 1
-                continue
-
-            norm = normalize_text(title)
-            if norm in existing_names or norm in seen_titles:
-                stats["skipped_duplicate"] += 1
-                continue
-            seen_titles.add(norm)
-
-            code = normalize_project_code(pj.get("codigo"))
-            enrichment = self._build_enrichment(
-                pj, code=code, strategy="new_from_document", needs_review=True
-            )
-            datas = pj.get("datas") or {}
-            start_sql = self._parse_sql_datetime(datas.get("inicio"))
-            end_sql = self._parse_sql_datetime(datas.get("fim"))
-            status = self._derive_status(datas.get("inicio"), datas.get("fim"))
-            description = descricao or geral
-
-            if self.dry_run:
-                logger.info(
-                    f"[dry-run][new] would create '{title[:60]}' (code={code or '-'}, {status})"
-                )
-                stats["created"] += 1
-                continue
-
-            result = self._session.execute(
-                text(
-                    """
-                    INSERT INTO initiatives
-                        (name, status, description, start_date, end_date,
-                         initiative_type_id, organization_id, parent_id, enrichment_json)
-                    VALUES (:name, :status, :desc, :start, :end, :type_id, :org_id, NULL, :j)
-                    """
-                ),
-                {
-                    "name": title,
-                    "status": status,
-                    "desc": description,
-                    "start": start_sql,
-                    "end": end_sql,
-                    "type_id": type_id,
-                    "org_id": org_id,
-                    "j": json.dumps(enrichment, ensure_ascii=False),
-                },
-            )
-            self._session.commit()
-            new_id = result.lastrowid
-            self._record_tracking(
-                init_id=new_id,
-                code=code,
-                strategy="new_from_document",
-                enrichment=enrichment,
-                desc_written=description,
-                path=path,
-                pj=pj,
-            )
-            existing_names.add(norm)
-            stats["created"] += 1
-            logger.info(f"[new] initiative {new_id} created: {title[:60]} ({status})")
-
-        logger.info(
-            f"Ingest unmatched complete ({'dry-run' if self.dry_run else 'applied'}): {stats}"
-        )
-        return stats

--- a/src/flows/sigpesq/enrich_projects.py
+++ b/src/flows/sigpesq/enrich_projects.py
@@ -15,37 +15,34 @@ def enrich_projects_flow(
     pj_dir: str = DEFAULT_PJ_DIR,
     overwrite: bool = False,
     dry_run: bool = False,
-    ingest_new: bool = False,
+    ingest_new: bool = True,
 ) -> dict:
     """
-    Enriches Research Project initiatives already in the database with content
-    extracted from the SigPesq project document files (``PJ_*.json``).
+    Enriches Research Project initiatives with content extracted from the SigPesq
+    project document files (``PJ_*.json``).
 
     Fills empty descriptions and stores the richer document fields (objectives,
-    schedule, research line, keywords) in ``initiatives.enrichment_json``. Only
-    projects that already map to an existing Research Project initiative are
-    touched; the code-matched ones are approved projects, title/fuzzy matches are
-    flagged for review inside the enrichment payload.
+    schedule, research line, keywords) in ``initiatives.enrichment_json``.
+
+    ``ingest_new`` (default True): rich documents that match no existing
+    initiative are created as new Research Projects, flagged ``needs_review`` in
+    their enrichment payload. This is idempotent — on later runs those documents
+    match by title and are not recreated — so the automated pipeline reproduces
+    the same set instead of relying on a manual one-off run.
     """
     logger = get_run_logger()
     logger.info("Initializing SigPesq Project Enrichment Flow")
 
     loader = ProjectEnrichmentLoader(overwrite=overwrite, dry_run=dry_run)
 
-    def _run():
-        result = {"enrichment": loader.load(pj_dir)}
-        if ingest_new:
-            result["ingest"] = loader.ingest_unmatched(pj_dir)
-        return result
-
     if dry_run:
-        stats = _run()
+        stats = loader.run(pj_dir, ingest_new=ingest_new)
     else:
         with tracking_recorder.run_context(
             source_system=ProjectEnrichmentLoader.SOURCE_SYSTEM,
             flow_name="Enrich SigPesq Projects",
         ):
-            stats = _run()
+            stats = loader.run(pj_dir, ingest_new=ingest_new)
 
     logger.info(f"Enrichment finished: {stats}")
     return stats

--- a/tests/test_project_enrichment.py
+++ b/tests/test_project_enrichment.py
@@ -1,0 +1,244 @@
+"""Unit tests for the pure (DB-free) logic of ProjectEnrichmentLoader."""
+
+from datetime import datetime
+
+import pytest
+
+from src.core.logic.project_enrichment import (
+    Candidate,
+    Match,
+    build_enrichment,
+    compose_description,
+    derive_status,
+    is_ingestable,
+    match_pj,
+    normalize_project_code,
+    parse_sql_datetime,
+    resolve_claims,
+)
+
+
+# --------------------------------------------------------------- normalize_project_code
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("PJ 6020", "6020"),
+        ("PJ_6020", "6020"),
+        ("6020", "6020"),
+        ("PJ abc", ""),
+        (None, ""),
+        ("", ""),
+    ],
+)
+def test_normalize_project_code(value, expected):
+    assert normalize_project_code(value) == expected
+
+
+# --------------------------------------------------------------- compose_description
+def test_compose_description_prefers_descricao():
+    pj = {"descricao": "  resumo  ", "objetivos": {"geral": "obj"}}
+    assert compose_description(pj) == "resumo"
+
+
+def test_compose_description_falls_back_to_objetivo_geral():
+    pj = {"descricao": "", "objetivos": {"geral": " meta geral "}}
+    assert compose_description(pj) == "meta geral"
+
+
+def test_compose_description_none_when_empty():
+    assert compose_description({"descricao": "", "objetivos": {}}) is None
+    assert compose_description({}) is None
+
+
+# --------------------------------------------------------------- build_enrichment
+def test_build_enrichment_shape():
+    pj = {
+        "objetivos": {"geral": "g", "especificos": ["a"]},
+        "cronograma": [{"atividade": "x"}],
+        "linha_pesquisa": "PLN",
+        "palavras_chave": ["k"],
+        "area_conhecimento": "CC",
+        "_meta": {
+            "extraido_em": "2026-07-18",
+            "modelo": "mistral",
+            "arquivo": "PJ_1.pdf",
+        },
+    }
+    e = build_enrichment(pj, code="6020", strategy="title_fuzzy", needs_review=True)
+    assert e["project_code"] == "6020"
+    assert e["match_strategy"] == "title_fuzzy"
+    assert e["needs_review"] is True
+    assert e["objetivos"]["especificos"] == ["a"]
+    assert e["cronograma"][0]["atividade"] == "x"
+    assert e["extraction_model"] == "mistral"
+    assert e["source_file"] == "PJ_1.pdf"
+
+
+def test_build_enrichment_empty_code_becomes_none():
+    e = build_enrichment({}, code="", strategy="new_from_document", needs_review=True)
+    assert e["project_code"] is None
+    assert e["objetivos"] == {}
+    assert e["cronograma"] == []
+    assert e["palavras_chave"] == []
+
+
+# --------------------------------------------------------------- parse_sql_datetime
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("2020-08-01", "2020-08-01 00:00:00.000000"),
+        ("2020-08-01T10:00:00", "2020-08-01 00:00:00.000000"),
+        ("2020-08", None),
+        ("garbage", None),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_parse_sql_datetime(value, expected):
+    assert parse_sql_datetime(value) == expected
+
+
+# --------------------------------------------------------------- derive_status
+def test_derive_status_concluded_when_end_in_past():
+    now = datetime(2026, 7, 20)
+    assert derive_status("2020-01-01", "2021-01-01", now=now) == "Concluded"
+
+
+def test_derive_status_active_when_end_in_future():
+    now = datetime(2026, 7, 20)
+    assert derive_status("2026-01-01", "2027-01-01", now=now) == "Active"
+
+
+def test_derive_status_active_with_start_no_end():
+    now = datetime(2026, 7, 20)
+    assert derive_status("2026-01-01", None, now=now) == "Active"
+
+
+def test_derive_status_unknown_without_dates():
+    now = datetime(2026, 7, 20)
+    assert derive_status(None, None, now=now) == "Unknown"
+
+
+# --------------------------------------------------------------- is_ingestable
+def test_is_ingestable_requires_title_desc_and_objectives_or_schedule():
+    assert is_ingestable({"titulo": "T", "descricao": "D", "objetivos": {"geral": "g"}})
+    assert is_ingestable(
+        {"titulo": "T", "descricao": "D", "cronograma": [{"atividade": "a"}]}
+    )
+    # missing description
+    assert not is_ingestable({"titulo": "T", "objetivos": {"geral": "g"}})
+    # missing title
+    assert not is_ingestable({"descricao": "D", "objetivos": {"geral": "g"}})
+    # no objectives and no schedule
+    assert not is_ingestable({"titulo": "T", "descricao": "D"})
+
+
+# --------------------------------------------------------------- match_pj
+CODE_INDEX = {"6020": 10}
+NAME_INDEX = {
+    "correcao automatica de redacoes": [20],
+    "titulo repetido": [30, 31],
+}
+FUZZY = {
+    20: "correcao automatica de redacoes",
+    30: "titulo repetido",
+    31: "titulo repetido",
+    40: "mapeamento dos dados do enem por municipio do espirito santo",
+}
+
+
+def test_match_by_code_wins():
+    m = match_pj(
+        {"codigo": "PJ 6020", "titulo": "irrelevante"}, CODE_INDEX, NAME_INDEX, FUZZY
+    )
+    assert m == Match(10, "sigpesq_project_code", False)
+
+
+def test_match_exact_title_unique():
+    m = match_pj(
+        {"codigo": None, "titulo": "Correção Automática de Redações"},
+        CODE_INDEX,
+        NAME_INDEX,
+        FUZZY,
+    )
+    assert m == Match(20, "title_exact", False)
+
+
+def test_match_exact_title_ambiguous_flags_review():
+    m = match_pj({"titulo": "Título Repetido"}, CODE_INDEX, NAME_INDEX, FUZZY)
+    assert m.strategy == "title_exact"
+    assert m.needs_review is True
+    assert m.initiative_id in (30, 31)
+
+
+def test_match_fuzzy_above_threshold():
+    # one-char difference from initiative 40's normalized name -> ratio >= 90
+    m = match_pj(
+        {"titulo": "Mapeamento dos dados do ENEM por municipio do Espirito Santoo"},
+        CODE_INDEX,
+        NAME_INDEX,
+        FUZZY,
+    )
+    assert m is not None
+    assert m.strategy == "title_fuzzy"
+    assert m.initiative_id == 40
+    assert m.needs_review is True
+
+
+def test_match_none_when_dissimilar():
+    m = match_pj(
+        {"titulo": "assunto totalmente diferente e sem relacao"},
+        CODE_INDEX,
+        NAME_INDEX,
+        FUZZY,
+    )
+    assert m is None
+
+
+def test_match_none_without_title_or_code():
+    assert match_pj({"titulo": None}, CODE_INDEX, NAME_INDEX, FUZZY) is None
+
+
+# --------------------------------------------------------------- resolve_claims
+def _cand(path, init_id, strategy):
+    return Candidate(path, {"codigo": path}, Match(init_id, strategy, False))
+
+
+def test_resolve_claims_code_beats_title_on_same_initiative():
+    cands = [
+        _cand("PJ_b.json", 100, "title_exact"),
+        _cand("PJ_a.json", 100, "sigpesq_project_code"),
+    ]
+    winners, collisions = resolve_claims(cands)
+    assert collisions == 1
+    assert len(winners) == 1
+    assert winners[0].match.strategy == "sigpesq_project_code"
+
+
+def test_resolve_claims_keeps_distinct_initiatives():
+    cands = [
+        _cand("PJ_a.json", 1, "sigpesq_project_code"),
+        _cand("PJ_b.json", 2, "title_exact"),
+        _cand("PJ_c.json", 3, "title_fuzzy"),
+    ]
+    winners, collisions = resolve_claims(cands)
+    assert collisions == 0
+    assert {w.match.initiative_id for w in winners} == {1, 2, 3}
+
+
+def test_resolve_claims_ignores_unmatched():
+    cands = [Candidate("PJ_x.json", {}, None), _cand("PJ_y.json", 5, "title_exact")]
+    winners, collisions = resolve_claims(cands)
+    assert collisions == 0
+    assert [w.match.initiative_id for w in winners] == [5]
+
+
+def test_resolve_claims_tie_broken_by_path():
+    # same priority (both title_exact), same initiative -> first by filename wins
+    cands = [
+        _cand("PJ_z.json", 7, "title_exact"),
+        _cand("PJ_a.json", 7, "title_exact"),
+    ]
+    winners, collisions = resolve_claims(cands)
+    assert collisions == 1
+    assert winners[0].path == "PJ_a.json"


### PR DESCRIPTION
Aplica a review crítica do enrichment de projetos (#1/#2/#3/#8/#7).

## Mudanças
- **#1 Perf**: documentos lidos e casados **uma vez** (antes 2× o corpus quando `ingest_new`); fuzzy via `rapidfuzz.process.extractOne` (era `SequenceMatcher` O(N×M)). Dry-run 355 docs: **>120s → ~0,7s**.
- **#2 Atomicidade**: `run()` único escreve tudo em **uma transação** (antes: commit por linha).
- **#3 Resiliência**: cada escrita em `SAVEPOINT` (`begin_nested`) — linha que falha é pulada sem abortar as demais (`stats["errors"]`).
- **#8 Testes**: lógica pura extraída (`match_pj`, `resolve_claims`, `compose_description`, `derive_status`, `parse_sql_datetime`, `build_enrichment`, `is_ingestable`) + **32 testes** sem DB.
- **#7 Pipeline**: `enrich_projects_flow(ingest_new=True)` por padrão → os projetos novos dos documentos passam a ser **reproduzíveis** pelo pipeline (idempotente: casam por título em runs seguintes, não recriam).

## Verificação
- 35 testes verdes (`test_project_enrichment` + `test_sigpesq_project_mapping` + `test_export_initiatives`).
- Dry-run idempotente: re-run cria 0 novos, enriquece 310 (264 + 46 já existentes).

## Follow-up (não neste PR)
- #4 criar initiative via ORM/handler (não INSERT cru)
- #5 coluna `enrichment_json` via migração (não DDL em runtime)
- #6 normalizar enrichment (tabela/colunas tipadas) para querytabilidade

🤖 Generated with [Claude Code](https://claude.com/claude-code)