### PR TITLE
chore(deps): bump agent_sigpesq v0.3.0 → v0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "rapidfuzz>=3.0.0",
     "python-Levenshtein>=0.25.0",
     "python-dotenv>=1.0.0",
-    "sigpesq-agent @ git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.0",
+    "sigpesq-agent @ git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.2",
     "dgp-cnpq-lib @ git+https://github.com/ifesserra-lab/dgp.cnqp_lib.git@v0.5.0",
     "scriptLattes @ git+https://github.com/ifesserra-lab/scriptLattes.git@v0.8.0",
     "selenium>=4.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ thefuzz>=0.22.0
 rapidfuzz>=3.0.0
 python-Levenshtein>=0.25.0
 python-dotenv>=1.0.0
-git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.0
+git+https://github.com/ifesserra-lab/sigpesq_agent.git@v0.3.2
 git+https://github.com/ifesserra-lab/dgp.cnqp_lib.git@v0.5.0
 scriptLattes @ git+https://github.com/ifesserra-lab/scriptLattes.git@v0.8.0
 selenium>=4.0.0


### PR DESCRIPTION
Atualiza a dependência git `sigpesq_agent` (ifesserra-lab) para a última release **v0.3.2** (era v0.3.0).

Verificado: imports usados pelo adapter/flows (`SigpesqReportService`, `ResearchGroupsDownloadStrategy`/`ProjectsDownloadStrategy`/`AdvisorshipsDownloadStrategy`, `browser_factory`) + `SigPesqAdapter`/`ingest_sigpesq_flow` carregam OK com a nova versão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)