### PR TITLE
docs(adr): ADR 002 (enrichment de projetos) + ADR 003 (Parquet)

### DIFF
--- a/docs/2 - implementacao/ADR/002-sigpesq-project-document-enrichment.md
+++ b/docs/2 - implementacao/ADR/002-sigpesq-project-document-enrichment.md
@@ -1,0 +1,55 @@
+# ADR 002: Enrichment de Projetos a partir dos Documentos SigPesq (PJ)
+
+* Status: Accepted
+* Deciders: Claude, Paulo
+* Date: 2026-07-20
+
+Technical Story: O relatório Excel do SigPesq só traz um resumo raso dos projetos (e apenas os aprovados/recentes — ~101 linhas). Os planos de projeto em PDF/DOC contêm descrição completa, objetivos, cronograma e linha de pesquisa. Um processo externo extraiu esses documentos por LLM para `data/exports/project_sigpesq_files_json/PJ_*.json` (355 arquivos). Faltava incorporá-los ao modelo canônico.
+
+## Context and Problem Statement
+
+70,6% das iniciativas tinham `description` nula. Os campos ricos dos documentos (objetivos, cronograma datado, linha de pesquisa, palavras-chave) **não têm coluna** na tabela `initiatives`. Além disso, ~260 projetos dos documentos não existiam no banco (fora do snapshot do Excel). Precisávamos: (a) enriquecer o que existe sem sobrescrever dados de fontes mais autoritativas, (b) decidir onde persistir os campos sem coluna, (c) decidir o que fazer com os projetos ausentes.
+
+## Decision Drivers
+
+* Não sobrescrever dados de fontes autoritativas (Excel `Resumo`, Lattes/CNPq) — coerente com o [ADR 001](001-strict-idempotency-sigpesq.md).
+* Extração por LLM é ruidosa → matches incertos precisam ser auditáveis.
+* Idempotência: rodar no pipeline semanal não pode duplicar nem divergir.
+* Rastreabilidade (fonte, modelo de extração, estratégia de match).
+
+## Considered Options
+
+* **Match**: (1) só por código SigPesq; (2) código + título exato; (3) código + título exato + fuzzy.
+* **Persistência dos campos ricos**: (A) coluna JSON `enrichment_json`; (B) só `attribute_assertions` (audit, não exportado); (C) tabela normalizada `initiative_enrichment`.
+* **Projetos ausentes**: (i) ignorar; (ii) ingerir os "ricos" como novas iniciativas.
+
+## Decision Outcome
+
+* **Match em cascata por confiança**: `sigpesq_project_code` (via tracking tables; são aprovados) → `title_exact` → `title_fuzzy` (rapidfuzz ≥ 90). Dedupe por prioridade: cada iniciativa é reivindicada uma vez pelo match mais confiável (código vence título), evitando que um match fraco sobrescreva um forte.
+* **Persistência = coluna JSON `enrichment_json`** (Opção A). `metadata` era inviável (nome reservado do SQLAlchemy — nunca persistia). `description` (único campo canônico com coluna) é preenchido **só quando vazio** (salvo `overwrite=True`).
+* **`needs_review`** no payload marca matches por título/fuzzy e projetos novos.
+* **Ingestão de ausentes ricos** (título + descrição + objetivos/cronograma) como novas iniciativas (Opção ii), com dedupe de título e `needs_review`. Idempotente: em runs seguintes casam por título e não são recriados.
+* Roda no pipeline **após** SigPesq + Lattes (o title-match usa iniciativas Lattes) e **antes** do export.
+
+### Consequences
+
+* Good: 70,6% → ~68% de descrições nulas preenchidas onde há documento; objetivos/cronograma/linha/keywords passam a existir (antes em nenhuma iniciativa).
+* Good: proveniência completa (source_records + entity_matches + attribute_assertions + change_logs) com `match_strategy`/`needs_review`.
+* Good: idempotente e reprodutível pelo pipeline (sem passo manual).
+* Bad: `enrichment_json` é blob → não filtrável por SQL (ver [ADR 003](003-parquet-canonical-storage.md) e follow-up de normalização).
+* Bad: `title_fuzzy` pode gerar falso-positivo — mitigado por `needs_review`, não eliminado.
+* Bad: coluna criada via DDL em runtime (`ensure_schema`) — stopgap até adotar ferramenta de migração.
+
+## Pros and Cons of the Options
+
+### Persistência A — coluna JSON `enrichment_json`
+* Good: simples, export direto no `initiatives_canonical.json`, sem migração pesada.
+* Bad: não normalizado; sem validação de schema; não querytável em SQL.
+
+### Persistência B — só attribute_assertions
+* Good: zero mudança de schema; audit nativo.
+* Bad: dado fica "enterrado" no log de auditoria; não aparece no export nem para o dashboard.
+
+### Persistência C — tabela normalizada
+* Good: querytável, tipado.
+* Bad: mais invasivo (modelo/migração/ORM); adiado como follow-up.

--- a/docs/2 - implementacao/ADR/003-parquet-canonical-storage.md
+++ b/docs/2 - implementacao/ADR/003-parquet-canonical-storage.md
@@ -1,0 +1,53 @@
+# ADR 003: Parquet como Formato de Armazenamento/Consumo dos Exports Canônicos
+
+* Status: Accepted
+* Deciders: Claude, Paulo
+* Date: 2026-07-20
+
+Technical Story: Os exports canônicos em JSON somam ~255 MB (44 arquivos), e o dashboard irmão (`horizon_dashboard`) versiona cópias desses JSON em `src/data` (~322 MB no git). O repositório e o build ficaram pesados. Avaliou-se migrar o armazenamento/consumo para Parquet.
+
+## Context and Problem Statement
+
+As tabelas grandes (provenance: `attribute_assertions` 45 MB, trackings, `source_records`) dominam o volume. O dashboard é **SSG** (Astro): os dados são embutidos no build, o browser **não** baixa os JSON. Logo, o custo do JSON é de **repositório e build**, não de página. Precisávamos reduzir esse peso sem mudar a saída do site nem quebrar consumidores.
+
+## Decision Drivers
+
+* Reduzir tamanho de repositório/zip/transferência.
+* Não alterar o HTML gerado (SSG) nem o consumo por LLM/humano do que precisa ser legível.
+* Baixo atrito de migração no dashboard (evitar reescrever dezenas de imports para async).
+* Preservar fidelidade (round-trip exato).
+
+## Considered Options
+
+* **Formato**: (1) manter JSON; (2) tudo Parquet; (3) híbrido (Parquet nas tabelas, JSON nos aninhados pequenos/grafos).
+* **Consumo no dashboard**: (A) leitura em build-time (plugin Vite decodifica Parquet → objeto, imports continuam síncronos); (B) leitura em runtime (browser + duckdb-wasm/hyparquet).
+* **Compressão**: snappy (zero dep no leitor) vs zstd (menor, precisa de lib).
+
+## Decision Outcome
+
+* **Híbrido (Opção 3)**: tabelas array-de-objetos → `<name>.parquet`; grafos node-link → `<name>.nodes.parquet` + `<name>.edges.parquet` + `<name>.meta.json`; summaries/marts pequenos e `_meta` seguem JSON. Compressão **zstd**.
+* **ETL**: `src/scripts/export_parquet.py` + etapa `export_parquet_task` no `export_canonical_data_flow` emitem `data/exports/parquet/` (dentro do zip).
+* **Dashboard**: leitura **build-time** (Opção A) via `parquet-plugin.mjs` (Vite, `enforce: pre`) usando `hyparquet` + `hyparquet-compressors`. Imports seguem síncronos → churn mínimo. SSG inalterada.
+* **Runtime (Opção B) rejeitada** para o caso geral: adicionaria wasm ao usuário final sem necessidade (o dado já é embutido no build).
+
+### Consequences
+
+* Good: `src/data` do dashboard **322 MB → 93 MB**; tabelas top-level **255 MB → 15 MB (~6%)**. Fidelidade verificada (0 divergências).
+* Good: saída SSG idêntica; consumidores analíticos (pandas/DuckDB) ganham colunar/tipado.
+* Bad: **subdir de grafos por-grupo (78 MB) segue JSON** — convertê-lo fez o build embutir 345 grafos via o plugin e **estourar a heap (OOM, 8 GB)**; o JSON tem carregamento lazy nativo mais leve. Só daria para converter migrando esse caso para leitura em runtime (não feito).
+* Bad: 2 dependências novas no dashboard (`hyparquet`, `hyparquet-compressors`).
+* Bad: revival de campos aninhados no plugin é heurístico (string começando com `[`/`{`) — robusto o suficiente para estes dados, não em geral.
+
+## Pros and Cons of the Options
+
+### Consumo A — build-time (escolhido)
+* Good: imports síncronos, libs/páginas quase intocadas; SSG idêntica; sem peso ao usuário.
+* Bad: o build carrega tudo em memória → não escala para milhares de arquivos grandes embutidos (vide OOM do subdir).
+
+### Consumo B — runtime (browser)
+* Good: build leve; permite query client-side sobre datasets grandes.
+* Bad: adiciona wasm/fetch ao usuário; só compensa se houver feature de "explorar a base inteira ao vivo".
+
+### Compressão zstd vs snappy
+* zstd: ~2× menor; exige `hyparquet-compressors` (adotado).
+* snappy: zero dep no leitor, porém maior no repo.


### PR DESCRIPTION
Registra as decisões arquiteturais desta sessão como ADRs (formato do ADR 001).

- **ADR 002** — Enrichment de projetos a partir dos documentos SigPesq (PJ): match em cascata (código > título exato > fuzzy), `enrichment_json`, `needs_review`, ingestão dos projetos ausentes, idempotência.
- **ADR 003** — Parquet como formato de armazenamento/consumo: híbrido (tabelas parquet, grafos/summaries JSON), leitura build-time via plugin Vite/hyparquet, subdir de grafos segue JSON (OOM), zstd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)