### PR TITLE
refactor(enrichment): follow-ups da review (#4/#5/#6/#9/#10)

### DIFF
--- a/src/core/logic/project_enrichment.py
+++ b/src/core/logic/project_enrichment.py
@@ -5,12 +5,14 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-from eo_lib import InitiativeController
+from eo_lib import Initiative, InitiativeController
 from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
 from rapidfuzz import fuzz, process
 from sqlalchemy import text
 
 from src.core.logic.initiative_identity import normalize_text
+from src.db.migrations import run_migrations
 from src.tracking.recorder import tracking_recorder
 
 RESEARCH_PROJECT_TYPE = "Research Project"
@@ -18,6 +20,40 @@ RESEARCH_PROJECT_TYPE = "Research Project"
 FUZZY_THRESHOLD = 90.0
 NEW_FROM_DOCUMENT = "new_from_document"
 STRATEGY_PRIORITY = {"sigpesq_project_code": 0, "title_exact": 1, "title_fuzzy": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Enrichment payload schema (validated on build; stored as JSON in enrichment_json)
+# --------------------------------------------------------------------------- #
+class Objetivos(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    geral: Optional[str] = None
+    especificos: List[str] = Field(default_factory=list)
+
+
+class CronogramaItem(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    atividade: Optional[str] = None
+    inicio: Optional[str] = None
+    fim: Optional[str] = None
+
+
+class EnrichmentPayload(BaseModel):
+    """Typed, validated shape of ``initiatives.enrichment_json``."""
+
+    model_config = ConfigDict(extra="forbid")
+    source: str
+    project_code: Optional[str] = None
+    match_strategy: str
+    needs_review: bool
+    objetivos: Objetivos = Field(default_factory=Objetivos)
+    cronograma: List[CronogramaItem] = Field(default_factory=list)
+    linha_pesquisa: Optional[str] = None
+    palavras_chave: List[str] = Field(default_factory=list)
+    area_conhecimento: Optional[str] = None
+    extracted_at: Optional[str] = None
+    extraction_model: Optional[str] = None
+    source_file: Optional[str] = None
 
 
 # --------------------------------------------------------------------------- #
@@ -43,22 +79,38 @@ def compose_description(pj: Dict[str, Any]) -> Optional[str]:
 def build_enrichment(
     pj: Dict[str, Any], *, code: str, strategy: str, needs_review: bool
 ) -> Dict[str, Any]:
-    """Assembles the ``enrichment_json`` payload from a PJ document."""
+    """Assembles and VALIDATES the ``enrichment_json`` payload from a PJ document.
+
+    Returns a plain dict (``EnrichmentPayload.model_dump``); raises
+    ``pydantic.ValidationError`` on a malformed document so the row is skipped
+    (via the caller's savepoint) instead of persisting garbage.
+    """
     meta = pj.get("_meta") or {}
-    return {
-        "source": ProjectEnrichmentLoader.SOURCE_SYSTEM,
-        "project_code": code or None,
-        "match_strategy": strategy,
-        "needs_review": needs_review,
-        "objetivos": pj.get("objetivos") or {},
-        "cronograma": pj.get("cronograma") or [],
-        "linha_pesquisa": pj.get("linha_pesquisa"),
-        "palavras_chave": pj.get("palavras_chave") or [],
-        "area_conhecimento": pj.get("area_conhecimento"),
-        "extracted_at": meta.get("extraido_em"),
-        "extraction_model": meta.get("modelo"),
-        "source_file": meta.get("arquivo"),
-    }
+    payload = EnrichmentPayload(
+        source=ProjectEnrichmentLoader.SOURCE_SYSTEM,
+        project_code=code or None,
+        match_strategy=strategy,
+        needs_review=needs_review,
+        objetivos=pj.get("objetivos") or {},
+        cronograma=pj.get("cronograma") or [],
+        linha_pesquisa=pj.get("linha_pesquisa"),
+        palavras_chave=pj.get("palavras_chave") or [],
+        area_conhecimento=pj.get("area_conhecimento"),
+        extracted_at=meta.get("extraido_em"),
+        extraction_model=meta.get("modelo"),
+        source_file=meta.get("arquivo"),
+    )
+    return payload.model_dump()
+
+
+def parse_datetime(value: Any) -> Optional[datetime]:
+    """Parses a 'YYYY-MM-DD' prefix into a ``datetime`` (for the ORM), or None."""
+    if not value:
+        return None
+    match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", str(value))
+    if not match:
+        return None
+    return datetime(int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
 def parse_sql_datetime(value: Any) -> Optional[str]:
@@ -203,23 +255,9 @@ class ProjectEnrichmentLoader:
 
     # -------------------------------------------------------------- schema
     def ensure_schema(self) -> None:
-        """Adds the ``enrichment_json`` column to ``initiatives`` if missing.
-
-        NOTE: runtime DDL is a pragmatic stopgap — this belongs in a real
-        migration once the project adopts a migration tool.
-        """
-        cols = {
-            row[1]
-            for row in self._session.execute(
-                text("PRAGMA table_info(initiatives)")
-            ).fetchall()
-        }
-        if "enrichment_json" not in cols:
-            logger.info("Adding column initiatives.enrichment_json (TEXT)")
-            self._session.execute(
-                text("ALTER TABLE initiatives ADD COLUMN enrichment_json TEXT")
-            )
-            self._session.commit()
+        """Applies pending schema migrations (idempotent). Delegates DDL to the
+        migrations module instead of running ad-hoc ``ALTER`` in business logic."""
+        run_migrations(self._session)
 
     # -------------------------------------------------------------- indexes
     def _load_code_index(self) -> Dict[str, int]:
@@ -479,34 +517,32 @@ class ProjectEnrichmentLoader:
         )
         datas = pj.get("datas") or {}
         description = compose_description(pj)
-        params = {
-            "name": (pj.get("titulo") or "").strip(),
-            "status": derive_status(
-                datas.get("inicio"), datas.get("fim"), now=datetime.now()
-            ),
-            "desc": description,
-            "start": parse_sql_datetime(datas.get("inicio")),
-            "end": parse_sql_datetime(datas.get("fim")),
-            "type_id": type_id,
-            "org_id": org_id,
-            "j": json.dumps(enrichment, ensure_ascii=False),
-        }
+        name = (pj.get("titulo") or "").strip()
         new_id_box: Dict[str, Optional[int]] = {"id": None}
 
         def _do():
-            result = self._session.execute(
-                text(
-                    """
-                    INSERT INTO initiatives
-                        (name, status, description, start_date, end_date,
-                         initiative_type_id, organization_id, parent_id, enrichment_json)
-                    VALUES (:name, :status, :desc, :start, :end,
-                            :type_id, :org_id, NULL, :j)
-                    """
+            # Create through the ORM entity so SQLAlchemy defaults and the
+            # session's before_flush hooks (e.g. LGPD anonymization) fire.
+            # flush() (not commit) keeps this inside the run() transaction.
+            initiative = Initiative(
+                name=name,
+                status=derive_status(
+                    datas.get("inicio"), datas.get("fim"), now=datetime.now()
                 ),
-                params,
+                description=description,
+                start_date=parse_datetime(datas.get("inicio")),
+                end_date=parse_datetime(datas.get("fim")),
+                initiative_type_id=type_id,
+                organization_id=org_id,
             )
-            new_id_box["id"] = result.lastrowid
+            self._session.add(initiative)
+            self._session.flush()
+            new_id_box["id"] = initiative.id
+            # enrichment_json has no ORM column mapping -> raw UPDATE, same txn.
+            self._session.execute(
+                text("UPDATE initiatives SET enrichment_json = :j WHERE id = :id"),
+                {"j": json.dumps(enrichment, ensure_ascii=False), "id": initiative.id},
+            )
 
         if not self._write_row(_do):
             return False
@@ -520,9 +556,7 @@ class ProjectEnrichmentLoader:
             path=cand.path,
             pj=pj,
         )
-        logger.info(
-            f"[new] initiative {new_id_box['id']} created: {params['name'][:60]}"
-        )
+        logger.info(f"[new] initiative {new_id_box['id']} created: {name[:60]}")
         return True
 
     # -------------------------------------------------------------- write helpers

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -1,0 +1,58 @@
+"""Minimal, dependency-free schema migrations for the canonical SQLite database.
+
+The project does not (yet) use Alembic. This module keeps schema changes out of
+business logic: each migration is applied at most once and recorded in a
+``schema_migrations`` table. ``ALTER TABLE ... ADD COLUMN`` is guarded so it is
+idempotent even against databases where the column was already added by the
+previous runtime-DDL stopgap.
+
+Run at pipeline/app start, or lazily via ``ProjectEnrichmentLoader.ensure_schema``.
+"""
+
+from typing import List, Tuple
+
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+# (id, SQL). Order matters; ids are immutable once shipped.
+MIGRATIONS: List[Tuple[str, str]] = [
+    (
+        "0001_initiatives_enrichment_json",
+        "ALTER TABLE initiatives ADD COLUMN enrichment_json TEXT",
+    ),
+]
+
+
+def _applied_ids(session) -> set:
+    session.execute(
+        text(
+            "CREATE TABLE IF NOT EXISTS schema_migrations "
+            "(id TEXT PRIMARY KEY, applied_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+        )
+    )
+    return {row[0] for row in session.execute(text("SELECT id FROM schema_migrations"))}
+
+
+def run_migrations(session) -> int:
+    """Applies pending migrations. Returns the number applied. Commits its own work."""
+    applied = _applied_ids(session)
+    count = 0
+    for migration_id, sql in MIGRATIONS:
+        if migration_id in applied:
+            continue
+        try:
+            session.execute(text(sql))
+        except OperationalError as exc:
+            # ADD COLUMN on an already-migrated DB (legacy runtime DDL) is fine.
+            if "duplicate column" not in str(exc).lower():
+                session.rollback()
+                raise
+        session.execute(
+            text("INSERT OR IGNORE INTO schema_migrations (id) VALUES (:id)"),
+            {"id": migration_id},
+        )
+        count += 1
+        logger.info("Applied migration {}", migration_id)
+    session.commit()
+    return count

--- a/src/scripts/export_parquet.py
+++ b/src/scripts/export_parquet.py
@@ -3,13 +3,16 @@ Convert the JSON canonical exports into a Parquet layout for storage/consumption
 
 Layout produced in the destination directory:
 
-* array-of-objects file  ->  ``<name>.parquet`` (nested object/list fields are
-  stored as JSON strings; readers revive them with ``JSON.parse``).
+* array-of-objects file  ->  ``<name>.parquet`` (+ ``<name>.cols.json`` sidecar).
 * node-link graph file    ->  ``<name>.nodes.parquet`` + ``<name>.edges.parquet``
-  + ``<name>.meta.json`` (the small ``metadata`` / ``graph_stats`` /
-  ``directed`` / ``multigraph`` wrapper).
-* other small object (marts, summaries, ``_meta``)  ->  copied as ``<name>.json``
-  (already tiny and deeply nested; Parquet adds no value).
+  (+ their ``.cols.json`` sidecars) + ``<name>.meta.json``.
+* other small object (marts, summaries, ``_meta``)  ->  copied as ``<name>.json``.
+
+Nested (object/list) fields are stored as JSON strings; the reader revives them.
+The ``<name>.cols.json`` sidecar (``{"json_columns": [...]}``) tells the reader
+EXACTLY which columns were JSON-encoded, so it never has to guess (see the
+dashboard's parquet plugin). Id-like columns are pinned to a nullable integer
+dtype so they don't round-trip as floats (e.g. ``4737.0``).
 
 Round-trips losslessly for the homogeneous canonical/graph tables. Usage::
 
@@ -23,26 +26,48 @@ import os
 import shutil
 
 import pandas as pd
+from loguru import logger
 
 COMPRESSION = "zstd"
+NESTED_TYPES = (dict, list)
 
 
-def _stringify_nested(df: pd.DataFrame) -> pd.DataFrame:
+def _is_id_column(name: str) -> bool:
+    return name == "id" or name.endswith("_id")
+
+
+def _first_non_null(series: pd.Series):
+    non_null = series.dropna()
+    return non_null.iloc[0] if len(non_null) else None
+
+
+def _encode_columns(df: pd.DataFrame) -> list:
+    """Stringifies nested columns (in place) and pins id-like columns to a nullable
+    integer dtype. Returns the list of columns that were JSON-encoded."""
+    json_columns = []
     for col in df.columns:
-        if df[col].dtype == object:
-            df[col] = df[col].apply(
-                lambda v: (
-                    v
-                    if isinstance(v, (str, type(None)))
-                    else json.dumps(v, ensure_ascii=False)
-                )
-            )
-    return df
+        sample = _first_non_null(df[col])
+        if isinstance(sample, NESTED_TYPES):
+            df[col] = [
+                json.dumps(v, ensure_ascii=False) if isinstance(v, NESTED_TYPES) else v
+                for v in df[col]
+            ]
+            json_columns.append(col)
+        elif _is_id_column(col):
+            try:
+                df[col] = pd.to_numeric(df[col]).astype("Int64")
+            except (ValueError, TypeError):
+                pass  # non-numeric id (already a string) — leave as is
+    return json_columns
 
 
 def _write_table(rows: list, path: str) -> None:
     df = pd.json_normalize(rows, max_level=0)
-    _stringify_nested(df).to_parquet(path, compression=COMPRESSION, index=False)
+    json_columns = _encode_columns(df)
+    df.to_parquet(path, compression=COMPRESSION, index=False)
+    sidecar = path[: -len(".parquet")] + ".cols.json"
+    with open(sidecar, "w", encoding="utf-8") as fh:
+        json.dump({"json_columns": json_columns}, fh, ensure_ascii=False)
 
 
 def _is_graph(data) -> bool:
@@ -95,7 +120,7 @@ def convert_dir(src: str, dst: str) -> dict:
         try:
             stats[convert_file(path, dst)] += 1
         except Exception as exc:  # keep going; report at the end
-            print(f"ERROR converting {os.path.basename(path)}: {exc}")
+            logger.warning("Failed converting {}: {}", os.path.basename(path), exc)
             stats["error"] += 1
     return stats
 
@@ -108,7 +133,7 @@ def main() -> None:
     parser.add_argument("--dst", default="data/exports_parquet")
     args = parser.parse_args()
     stats = convert_dir(args.src, args.dst)
-    print(f"Parquet conversion complete: {stats} -> {args.dst}")
+    logger.info("Parquet conversion complete: {} -> {}", stats, args.dst)
 
 
 if __name__ == "__main__":

--- a/tests/test_project_enrichment.py
+++ b/tests/test_project_enrichment.py
@@ -77,9 +77,23 @@ def test_build_enrichment_shape():
 def test_build_enrichment_empty_code_becomes_none():
     e = build_enrichment({}, code="", strategy="new_from_document", needs_review=True)
     assert e["project_code"] is None
-    assert e["objetivos"] == {}
+    # objetivos is validated/normalized by the Pydantic model
+    assert e["objetivos"] == {"geral": None, "especificos": []}
     assert e["cronograma"] == []
     assert e["palavras_chave"] == []
+
+
+def test_build_enrichment_rejects_malformed_payload():
+    from pydantic import ValidationError
+
+    # palavras_chave must be a list of strings; a dict is invalid
+    with pytest.raises(ValidationError):
+        build_enrichment(
+            {"palavras_chave": {"nope": 1}},
+            code="1",
+            strategy="title_exact",
+            needs_review=False,
+        )
 
 
 # --------------------------------------------------------------- parse_sql_datetime


### PR DESCRIPTION
Implementa os follow-ups da review crítica do enrichment.

- **#4 (#109)** — criação de iniciativa via ORM (`Initiative` + `session.add` + `flush`) em vez de INSERT cru; dispara defaults/hooks (`before_flush` LGPD) e fica na transação única (`flush`, não `commit`); `enrichment_json` via UPDATE no mesmo txn.
- **#5 (#113)** — migrações em `src/db/migrations.py` (`schema_migrations` + runner idempotente); `ensure_schema` delega DDL (sem `ALTER` escondido no loader).
- **#6 (#110, parcial)** — payload validado por Pydantic (`EnrichmentPayload`); documento malformado é rejeitado e a linha pulada. **Normalização em tabela segue aberta em #110.**
- **#9 (#111)** — `export_parquet` pina ids em `Int64` (não float), stringifica só colunas aninhadas; `logger` no lugar de `print`.
- **#10 (#112, lado ETL)** — `export_parquet` emite sidecar `<name>.cols.json`. O lado consumidor (plugin do dashboard revive por lista, não heurística) vai em PR do dashboard.

## Verificação
- 33 testes de unidade (lógica pura + validação Pydantic).
- `export_parquet`: `id` dtype `Int64`, sidecar com `json_columns` correto.
- Dry-run real (355 docs, ingest_new): `errors=0`, idempotente (0 novos, 310 enriquecidos).

Closes #109, #111, #113. Parcial #110 (validação); #112 completa com o PR do dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)